### PR TITLE
Handle file/directory collision

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -39,25 +39,26 @@ export function uriToFilePath(record: WARCRecord) {
 		throw new Error("WARC-Target-URI header is required");
 	}
 
-    // replace multiple slashes with a single slash
+	// replace multiple slashes with a single slash
 	uri = uri.replace(/\/+/g, "/");
 
 	// if no extension, use `__index__` as filename and content type to determine the extension
-	if (uri.endsWith("/")) {
-        const contentType = record.httpHeaders?.headers.get("Content-Type") || "text/html";
-        const extension = mime.extension(contentType);
-		uri += `__index__.${extension}`;
+	if (uri.endsWith("/") || !uri.split("/")[uri.split("/").length - 1].includes(".")) {
+		uri = uri.replace(/\/$/, "")
+		const contentType = record.httpHeaders?.headers.get("Content-Type") || "text/html";
+		const extension = mime.extension(contentType);
+		uri += `/__index__.${extension}`;
 	} else {
-                // constrain the length of the filename to 255 characters
-                const uriParts = uri.split("/");
-                const filename = uriParts[uriParts.length - 1];
-                if (filename.length > 255) {
-                        const prefix = filename.slice(0, 190)
-                        const suffix = filename.slice(190)
-                        const hash = createHash('sha256').update(suffix).digest('hex');
-                        uri = uriParts.slice(0, -1).concat([`${prefix}_${hash}`]).join("/");
-                }
-        }
+		// constrain the length of the filename to 255 characters
+		const uriParts = uri.split("/");
+		const filename = uriParts[uriParts.length - 1];
+		if (filename.length > 255) {
+			const prefix = filename.slice(0, 190)
+			const suffix = filename.slice(190)
+			const hash = createHash('sha256').update(suffix).digest('hex');
+			uri = uriParts.slice(0, -1).concat([`${prefix}_${hash}`]).join("/");
+		}
+	}
     
 	return uri;
 }

--- a/test/lib/utils.test.ts
+++ b/test/lib/utils.test.ts
@@ -32,6 +32,10 @@ test("utils.uriToFilePath", async (t) => {
 			uri: "https://example.com/path/",
 			expected: "https:/example.com/path/__index__.html",
 		},
+		{
+			uri: "https://example.com/path",
+			expected: "https:/example.com/path/__index__.html",
+		},
 		{ uri: "file:///path/page.html", expected: "file:/path/page.html" },
 	];
 


### PR DESCRIPTION
This addresses #3, where extracting a page like `example.com/hello` prevents the directory from being created when you go to extract `example.com/hello/there.html` -- I don't think it's a complete fix, as a page like `example.com/bad.path` will still prevent `example.com/bad.path/thing.html` from being created.

This PR also restores some tabs that I mistakenly turned into spaces.